### PR TITLE
Test with Java 25

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,5 +6,6 @@ buildPlugin(
   forkCount: '1C', // run this number of tests in parallel for faster feedback.  If the number terminates with a 'C', the value will be multiplied by the number of available CPU cores
   useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
+    [platform: 'linux', jdk: 25],
     [platform: 'linux', jdk: 21],
 ])


### PR DESCRIPTION
## Test with Java 25

Java 25 released September 16, 2025.  Jenkins core (weekly) has supported Java 25 since Jenkins 2.534, Oct 28, 2025.  Jenkins core (LTS) has supported Java 25 since 2.541.1, Jan 21, 2026.  90% of the 250 most popular plugin repositories now compile and test with Java 25.

Compile and test on ci.jenkins.io with Java 25 and Java 21.

### Testing done

* Confirmed that automated tests pass with Java 25 on Linux

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
